### PR TITLE
change psycopg2-binary to psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django>=1.7
-psycopg2-binary
+psycopg2
 typing; python_version < '3.5'


### PR DESCRIPTION
According to https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary ,
psycopg2-binary is meant for beginners only.
For production use you are advised to use the source distribution.