### PR TITLE
fix UpdateReturningModel not calling save of subclass

### DIFF
--- a/src/django_pg_returning/models.py
+++ b/src/django_pg_returning/models.py
@@ -114,4 +114,4 @@ class UpdateReturningModel(models.Model):
         :return: Updated instance
         """
         self._returning_save = True
-        return super(UpdateReturningModel, self).save(*args, **kwargs)
+        return self.save(*args, **kwargs)


### PR DESCRIPTION
If you subclass from UpdateReturningModel and have overwritten `save`, your method is not called when calling `save_returning`.
The super call executes the save method of the class that is next in the MRO after `UpdateReturningModel`, skipping methods coming before