### PR TITLE
[FIX] Compatibility with Django 4.2 LTS

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         postgres-version: ["9.4", "9.5", "9.6", "10", "11", "12", "13"]
-        django-version: ["1.8", "1.9", "1.10", "1.11", "2.0", "2.1", "2.2", "3.0", "3.1", "3.2"]
+        django-version: ["1.8", "1.9", "1.10", "1.11", "2.0", "2.1", "2.2", "3.0", "3.1", "3.2", "4.0", "4.1", "4.2"]
         exclude:
         # Django 3.0+ doesn't support python 3.5
         - python-version: "3.5"

--- a/src/django_pg_returning/manager.py
+++ b/src/django_pg_returning/manager.py
@@ -79,7 +79,10 @@ class UpdateReturningMixin(object):
         fields = {}
 
         if not ignore_deferred:
-            self.query.deferred_to_data(fields, self._get_loaded_field_cb)
+            if django.VERSION < (4, 2):
+                self.query.deferred_to_data(fields, self._get_loaded_field_cb)
+            else:
+                self.query.get_select_mask()
 
         # No .only() or .defer() operations
         if not fields:
@@ -140,7 +143,10 @@ class UpdateReturningMixin(object):
         query._annotations = None
         query.select_for_update = False
         query.select_related = False
-        query.clear_ordering(force_empty=True)
+        if django.VERSION < (4, 2):
+            query.clear_ordering(force_empty=True)
+        else:
+            query.clear_ordering(force=True)
 
         return self._execute_sql(query, fields)
 


### PR DESCRIPTION
Found two compat issues when upgrading a project from Django 3.2 to 4.2:
- Django 4.2 refactored (mostly a rename) of `.deferred_to_data()` into `.get_select_mask()`
- Djanog also changed the `.clear_ordering()` argument `force_empty` split into two new arguments. We need to set only `force=True` of the two.